### PR TITLE
goversion

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,19 +3,23 @@ description: "Run Go vulerability checker"
 author: "Kevin Mulvey"
 inputs:
   packages:
-    description: 'Run govulncheck on these packages.'
+    description: "Run govulncheck on these packages."
     required: false
-    default: './...'
+    default: "./..."
+  go-version:
+    description: "GO version to use"
+    required: false
+    default: "1.19"
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
-    - name: Set up Go 
+    - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: ${{ inputs.go-version }}
     - name: Get govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest
       shell: bash
@@ -24,5 +28,5 @@ runs:
       shell: bash
 
 branding:
-  icon: 'alert-triangle'
-  color: 'red'
+  icon: "alert-triangle"
+  color: "red"


### PR DESCRIPTION
It looks like we use fixed go version and this may be confusing for bugs related to the standard library like the recent:  GO-2022-0988 or GO-2022-0969. The bug may persist in the project but govulncheck will skip it (or yield a false positive) as it checks different version of standard library.